### PR TITLE
Add create-docforge starter CLI

### DIFF
--- a/bin/create-docforge.js
+++ b/bin/create-docforge.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const install = args.includes('--install');
+  const targetArg = args.find(a => !a.startsWith('-')) || '.';
+  const targetDir = path.resolve(process.cwd(), targetArg);
+
+  const templateDir = path.join(__dirname, '..', 'starter');
+  copyDir(templateDir, targetDir);
+
+  const pkgPath = path.join(targetDir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    const version = require('../package.json').version;
+    if (pkg.dependencies && pkg.dependencies.docforge)
+      pkg.dependencies.docforge = `^${version}`;
+    pkg.name = path.basename(targetDir);
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  }
+
+  if (install) {
+    execSync('npm install', { cwd: targetDir, stdio: 'inherit' });
+  }
+
+  console.log(`DocForge starter created at ${targetDir}`);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "lunr": "^2.3.9",
     "js-yaml": "^4.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "bin": {
+    "create-docforge": "./bin/create-docforge.js"
+  }
 }

--- a/starter/config.yaml
+++ b/starter/config.yaml
@@ -1,0 +1,6 @@
+site:
+  title: "DocForge Docs"
+  description: "Simple static docs."
+
+navigation:
+  search: true

--- a/starter/content/advanced/api/endpoints.md
+++ b/starter/content/advanced/api/endpoints.md
@@ -1,0 +1,3 @@
+# API Endpoints
+
+Document your API here.

--- a/starter/content/getting-started/01-install.md
+++ b/starter/content/getting-started/01-install.md
@@ -1,0 +1,3 @@
+# Install
+
+Run `npm install` then `npm run build` to generate your site.

--- a/starter/content/getting-started/index.md
+++ b/starter/content/getting-started/index.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+This section helps you begin with DocForge.

--- a/starter/content/index.md
+++ b/starter/content/index.md
@@ -1,0 +1,3 @@
+# Welcome to DocForge
+
+This is your new documentation site. Start editing files in the `content/` folder.

--- a/starter/package.json
+++ b/starter/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-docforge-site",
+  "private": true,
+  "scripts": {
+    "dev": "eleventy --serve",
+    "build": "node node_modules/docforge/src/generator/index.js"
+  },
+  "dependencies": {
+    "docforge": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add `create-docforge` script to bootstrap new DocForge sites
- provide starter template with `content/`, `config.yaml` and basic `package.json`
- expose `create-docforge` binary via package.json

## Testing
- `node bin/create-docforge.js test-site`
- `node bin/create-docforge.js test-site-install --install` *(fails: No matching version found for docforge@^1.0.0)*

------
https://chatgpt.com/codex/tasks/task_b_686fd1fb9854832bad9648ddcba3c83e