### PR TITLE
Add documentation site content

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,0 +1,6 @@
+site:
+  title: "DocForge Docs"
+  description: "Simple static docs."
+
+navigation:
+  search: true

--- a/docs/content/advanced/api/endpoints.md
+++ b/docs/content/advanced/api/endpoints.md
@@ -1,0 +1,3 @@
+# API Endpoints
+
+If you expose APIs for your project, document them here. DocForge does not impose any format—just write Markdown.

--- a/docs/content/advanced/index.md
+++ b/docs/content/advanced/index.md
@@ -1,0 +1,3 @@
+# Advanced Topics
+
+Use this section for in-depth guides, such as API references or multi-version setups.

--- a/docs/content/customization/index.md
+++ b/docs/content/customization/index.md
@@ -1,0 +1,3 @@
+# Customizing Your Site
+
+Site settings live in `config.yaml`. You can change the title, logo, colors, and enable features like analytics or multi-language support.

--- a/docs/content/customization/plugins.md
+++ b/docs/content/customization/plugins.md
@@ -1,0 +1,13 @@
+# Writing Plugins
+
+Create JavaScript modules in the `plugins/` directory. Export hook functions such as `onParseMarkdown` or `onPageRendered` to modify the build.
+
+Example:
+
+```js
+module.exports = {
+  onPageRendered: async ({ html }) => {
+    return { html: html + '\n<!-- custom -->' };
+  }
+};
+```

--- a/docs/content/deployment/index.md
+++ b/docs/content/deployment/index.md
@@ -1,0 +1,9 @@
+# Deployment
+
+DocForge sites output to the `_site/` folder. Host the contents on any static server. For Netlify, include a `netlify.toml` file:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "_site"
+```

--- a/docs/content/features/index.md
+++ b/docs/content/features/index.md
@@ -1,0 +1,8 @@
+# Features Overview
+
+DocForge automatically turns your Markdown files into a full documentation site with a responsive layout and search.
+
+* Sidebar navigation generated from folders
+* Collapsible mobile menu and dark-mode switch
+* Client-side search powered by Lunr.js
+* Shortcodes for rich content (images, tabs, notes)

--- a/docs/content/getting-started/01-install.md
+++ b/docs/content/getting-started/01-install.md
@@ -1,0 +1,11 @@
+# Install DocForge
+
+1. Clone or download this repository.
+2. Run `npm install` to install dependencies.
+3. Start the local development server:
+
+```bash
+npm run dev
+```
+
+The site will be available at `http://localhost:8080`.

--- a/docs/content/getting-started/02-build.md
+++ b/docs/content/getting-started/02-build.md
@@ -1,0 +1,9 @@
+# Build the Site
+
+When you're ready to generate the static files, run:
+
+```bash
+npm run build
+```
+
+The output appears in the `_site/` folder.

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+This section walks you through installing DocForge and creating your first site.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,0 +1,15 @@
+# DocForge Documentation
+
+Welcome to the official documentation for **DocForge**, a lightweight static site generator designed for "Read&nbsp;the&nbsp;Docs" style websites.
+
+## Quick Start
+
+```bash
+npm install
+npm run dev # start local server at http://localhost:8080
+npm run build # generate the _site/ folder
+```
+
+DocForge converts Markdown files inside a `content/` folder into a full documentation site with search, navigation, and responsive design.
+
+Check the **Getting Started** section to learn how to install and run DocForge locally.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "docs",
+  "private": true,
+  "scripts": {
+    "dev": "eleventy --serve",
+    "build": "node node_modules/docforge/src/generator/index.js"
+  },
+  "dependencies": {
+    "docforge": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `docs` directory generated from the starter template
- fill in pages with getting started instructions, features and advanced topics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686fe2732064832bac51ddf802342a4b