### PR TITLE
Fix CLI build and update Netlify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ To make DocForge truly user-friendly, include these instructions in the starter 
   - `netlify.toml`:
     ```toml
     [build]
-      command = "npm run build"
+      command = "CI= npm run build"  # Avoid CI treating warnings as errors
       publish = "_site"
     ```
   - Connect the repo to Netlify by selecting **New site from Git** in your Netlify dashboard and picking this repository. Netlify will read `netlify.toml` so no extra setup is required. Once linked, pushes to `main` automatically build and deploy the site and pull requests get preview URLs.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "npm run build"
+  command = "CI= npm run build"
   publish = "_site"

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -166,3 +166,10 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
 }
 
 module.exports = { generate, buildNav };
+
+if (require.main === module) {
+  generate().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- execute `generate` when running the generator script directly
- run builds with `CI=` to avoid npm treating warnings as errors
- document the CI flag in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686fe66a15c8832bb54d255f8082e7f8