### PR TITLE
Fix netlify build by creating docs build script

### DIFF
--- a/build-docs.js
+++ b/build-docs.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const path = require('path');
+const { generate } = require('./src/generator');
+
+(async () => {
+  try {
+    const contentDir = path.join(__dirname, 'docs', 'content');
+    const configPath = path.join(__dirname, 'docs', 'config.yaml');
+    const outputDir = path.join(__dirname, '_site');
+    await generate({ contentDir, outputDir, configPath });
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "CI= npm run build"
+  command = "node build-docs.js"
   publish = "_site"

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="{{ config.theme.darkMode ? 'dark' : 'light' }}">
+<html lang="en" data-theme="{% if config.theme.darkMode %}dark{% else %}light{% endif %}">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{ title or config.site.title }}</title>
+  <title>{{ title | default(config.site.title) }}</title>
   <link rel="stylesheet" href="/assets/theme.css" />
 </head>
 <body>

--- a/templates/partials/footer.njk
+++ b/templates/partials/footer.njk
@@ -1,3 +1,3 @@
 <footer class="footer">
-  <p>&copy; {{ config.site.title }} {{ new Date().getFullYear() }}</p>
+  <p>&copy; {{ config.site.title }}</p>
 </footer>


### PR DESCRIPTION
## Summary
- add a dedicated build-docs.js script to generate the docs
- update netlify.toml to use the new build script
- switch generator to use Nunjucks directly instead of Eleventy
- fix template syntax errors

## Testing
- `npm test`
- `node build-docs.js`

------
https://chatgpt.com/codex/tasks/task_b_686fe8ff5778832b897ebbce56677dee