### PR TITLE
Copy assets into build output

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -154,6 +154,14 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
     }
     await fs.promises.copyFile(srcPath, destPath);
   }
+
+  // Copy project level assets folder into output
+  const projectAssets = path.resolve(__dirname, '..', '..', 'assets');
+  if (fs.existsSync(projectAssets)) {
+    const dest = path.join(outputDir, 'assets');
+    await fs.promises.mkdir(dest, { recursive: true });
+    await fs.promises.cp(projectAssets, dest, { recursive: true });
+  }
 }
 
 module.exports = { generate, buildNav };


### PR DESCRIPTION
## Summary
- ensure assets directory gets copied when generating site

## Testing
- `npm test`
- `node build-docs.js`


------
https://chatgpt.com/codex/tasks/task_b_686feec56778832b9098858b00f36d1b