### PR TITLE
Fix sidebar hierarchical navigation rendering

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -60,6 +60,7 @@ body {
   padding: 1rem;
 }
 .sidebar ul { list-style: none; padding: 0; }
+.sidebar ul ul { padding-left: 1rem; }
 .sidebar a { text-decoration: none; color: var(--text-color); }
 main {
   flex: 1;

--- a/templates/partials/sidebar.njk
+++ b/templates/partials/sidebar.njk
@@ -1,9 +1,18 @@
+{% macro renderNav(items) %}
+  <ul>
+  {% for item in items %}
+    <li>
+      <a href="{{ item.path }}">{{ item.page.title }}</a>
+      {% if item.children and item.children.length %}
+        {{ renderNav(item.children) }}
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+{% endmacro %}
+
 <aside class="sidebar" id="sidebar">
   <nav>
-    <ul>
-    {% for item in navigation %}
-      <li><a href="{{ item.path }}">{{ item.page.title }}</a></li>
-    {% endfor %}
-    </ul>
+    {{ renderNav(navigation) }}
   </nav>
 </aside>


### PR DESCRIPTION
## Summary
- recursively render nested navigation items in sidebar
- indent nested lists in sidebar styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686ff1c787ec832b8aaa99ef14c254b9