### PR TITLE
Fix asset copy path

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -176,11 +176,9 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
   }
 
   // Copy the main assets directory (theme, js, etc.)
-  const mainAssetsSrc = path.resolve(
-    configPath ? path.dirname(configPath) : process.cwd(),
-    '..',
-    'assets'
-  );
+  // Always resolve assets relative to the DocForge package so it works
+  // regardless of the current working directory or config location.
+  const mainAssetsSrc = path.resolve(__dirname, '../../assets');
   const mainAssetsDest = path.join(outputDir, 'assets');
 
   if (fs.existsSync(mainAssetsSrc)) {


### PR DESCRIPTION
## Summary
- ensure generator copies assets regardless of working directory

## Testing
- `npm test -- --runInBand`
- `node src/generator/index.js`

------
https://chatgpt.com/codex/tasks/task_b_686ff66c78d8832b82eba79102665806