### PR TITLE
Add display names and section info to navigation

### DIFF
--- a/__tests__/buildNav.test.js
+++ b/__tests__/buildNav.test.js
@@ -13,3 +13,22 @@ test('generates navigation tree', () => {
   const install = guide.children.find(c => c.name === 'install.md');
   expect(install.path).toBe('/guide/install.html');
 });
+
+test('adds display names and section flags', () => {
+  const pages = [
+    { file: '02-api.md', data: { title: 'API', order: 2 } },
+    { file: '01-guide/index.md', data: { title: 'Guide', order: 1 } },
+    { file: '01-guide/setup.md', data: { title: 'Setup', order: 2 } },
+    { file: 'index.md', data: { title: 'Home', order: 10 } }
+  ];
+  const nav = buildNav(pages);
+  expect(nav[0].name).toBe('index.md');
+  const guide = nav.find(n => n.name === '01-guide');
+  expect(guide.displayName).toBe('Guide');
+  expect(guide.isSection).toBe(true);
+  const api = nav.find(n => n.name === '02-api.md');
+  expect(api.displayName).toBe('API');
+  // alphabetical within same order
+  expect(nav[1].name).toBe('01-guide');
+  expect(nav[2].name).toBe('02-api.md');
+});


### PR DESCRIPTION
## Summary
- enhance `buildNav` to generate `displayName` and `isSection`
- sort navigation items by order then alphabetically and keep `index.md` first
- test new `buildNav` features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686ffcbb35a4832b9136d24334ab6b51