### PR TITLE
Add page URL to render context

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -179,7 +179,14 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
     const raw = await fs.promises.readFile(srcPath, 'utf8');
     const { content, data } = matter(raw);
     const body = require('marked').parse(content);
-    let html = env.render('layout.njk', { title: data.title || page.data.title, content: body });
+
+    const pageContext = {
+      title: data.title || page.data.title,
+      content: body,
+      page: { url: '/' + page.file.replace(/\.md$/, '.html') }
+    };
+
+    let html = env.render('layout.njk', pageContext);
     const result = await runHook('onPageRendered', { file: page.file, html });
     if (result && result.html) html = result.html;
     await fs.promises.writeFile(outPath, html);


### PR DESCRIPTION
## Summary
- expose the generated page URL when rendering pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686ffde58214832b8010cdbbedf18df5