### PR TITLE
Refactor sidebar navigation

### DIFF
--- a/templates/partials/sidebar.njk
+++ b/templates/partials/sidebar.njk
@@ -1,10 +1,21 @@
-{% macro renderNav(items) %}
+{% macro renderNav(items, pageUrl) %}
   <ul>
   {% for item in items %}
     <li>
-      <a href="{{ item.path }}">{{ item.page.title }}</a>
       {% if item.children and item.children.length %}
-        {{ renderNav(item.children) }}
+        {% set sectionPath = item.path | replace('index.html', '') %}
+        <details class="nav-section" {% if pageUrl.startsWith(sectionPath) %}open{% endif %}>
+          <summary>
+            <a href="{{ item.path }}" class="nav-link{% if item.path === pageUrl %} active{% endif %}">
+              {{ item.displayName or item.page.title }}
+            </a>
+          </summary>
+          {{ renderNav(item.children, pageUrl) }}
+        </details>
+      {% else %}
+        <a href="{{ item.path }}" class="nav-link{% if item.path === pageUrl %} active{% endif %}">
+          {{ item.displayName or item.page.title }}
+        </a>
       {% endif %}
     </li>
   {% endfor %}
@@ -13,6 +24,6 @@
 
 <aside class="sidebar" id="sidebar">
   <nav>
-    {{ renderNav(navigation) }}
+    {{ renderNav(navigation, page.url) }}
   </nav>
 </aside>


### PR DESCRIPTION
## Summary
- rewrite sidebar navigation template to use `<details>`/`<summary>` structure
- highlight active links and auto-expand current sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686fffdbaacc832bb46a4e18b6ef21e3