### PR TITLE
Display footer links

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -94,6 +94,14 @@ main {
   padding: 1rem;
   background: var(--sidebar-bg);
 }
+.footer-links {
+  margin-bottom: 0.5rem;
+}
+.footer-links a {
+  margin: 0 0.5rem;
+  text-decoration: none;
+  color: var(--text-color);
+}
 @media (max-width: 768px) {
   .sidebar {
     position: fixed;

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -4,3 +4,10 @@ site:
 
 navigation:
   search: true
+
+footer:
+  links:
+    - text: "GitHub"
+      url: "https://github.com/yourusername/DocForge"
+    - text: "License"
+      url: "/license.html"

--- a/templates/partials/footer.njk
+++ b/templates/partials/footer.njk
@@ -1,3 +1,10 @@
 <footer class="footer">
+  {% if config.footer.links %}
+    <nav class="footer-links">
+      {% for link in config.footer.links %}
+        <a href="{{ link.url }}">{{ link.text }}</a>
+      {% endfor %}
+    </nav>
+  {% endif %}
   <p>&copy; {{ config.site.title }}</p>
 </footer>


### PR DESCRIPTION
## Summary
- show configured footer links
- style footer links
- demonstrate footer links in example config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68700838e438832b9748b0c3ff489ebb