### PR TITLE
Rename DocForge to Archivox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# DocForge: Final Specification
+# Archivox: Final Specification
 
-[![Build Status](https://github.com/yourusername/DocForge/actions/workflows/ci.yml/badge.svg)](https://github.com/yourusername/DocForge/actions/workflows/ci.yml)
+[![Build Status](https://github.com/yourusername/Archivox/actions/workflows/ci.yml/badge.svg)](https://github.com/yourusername/Archivox/actions/workflows/ci.yml)
 
 **Version:** 1.0  
 **Date:** July 10, 2025  
-**Overview:** DocForge is a modular, lightweight static site generator (SSG) for building "Read the Docs"-style documentation sites. It prioritizes user simplicity: content is driven entirely by Markdown files in a `content` folder, which automatically determines page structure, titles, and sidebar links. No manual HTML, link creation, or complex setups are needed. The site is mobile-friendly, SEO-optimized, and deployable to Netlify or similar hosts.
+**Overview:** Archivox is a modular, lightweight static site generator (SSG) for building "Read the Docs"-style documentation sites. It prioritizes user simplicity: content is driven entirely by Markdown files in a `content` folder, which automatically determines page structure, titles, and sidebar links. No manual HTML, link creation, or complex setups are needed. The site is mobile-friendly, SEO-optimized, and deployable to Netlify or similar hosts.
 
-Built with Node.js (using libraries like Eleventy for templating, `marked` or `remark` for Markdown parsing, and Vanilla JS for client-side features), DocForge generates static HTML/CSS/JS files. It's extensible via plugins and config, but defaults to a minimal, fast workflow.
+Built with Node.js (using libraries like Eleventy for templating, `marked` or `remark` for Markdown parsing, and Vanilla JS for client-side features), Archivox generates static HTML/CSS/JS files. It's extensible via plugins and config, but defaults to a minimal, fast workflow.
 
-This final spec incorporates core features, enhancements for usability and performance, and explicit user instructions. It's designed to be implemented as an open-source GitHub repo with a CLI starter kit (e.g., `npx create-docforge my-site`).
+This final spec incorporates core features, enhancements for usability and performance, and explicit user instructions. It's designed to be implemented as an open-source GitHub repo with a CLI starter kit (e.g., `npx create-archivox my-site`).
 
 ## Quick Start
 
@@ -79,7 +79,7 @@ npm run build
 ## Folder Structure
 
 ```
-my-docforge-site/
+my-archivox-site/
 ├── content/                  # Markdown-driven content
 │   ├── introduction.md       # Top-level: "Introduction"
 │   ├── getting-started/      # Section: "Getting Started"
@@ -109,7 +109,7 @@ Example:
 
 ```yaml
 site:
-  title: "DocForge Docs"
+  title: "Archivox Docs"
   description: "Simple static docs."
   logo: "/assets/logo.svg"
   favicon: "/assets/favicon.ico"
@@ -127,7 +127,7 @@ footer:
   social:
     - icon: "twitter"
       url: "https://x.com"
-  copyright: "© 2025 DocForge"
+  copyright: "© 2025 Archivox"
 
 theme:
   name: "minimal"
@@ -158,7 +158,7 @@ plugins:
 
 ## User Instructions: Formatting and Placing Markdown
 
-To make DocForge truly user-friendly, include these instructions in the starter repo's `README.md` (which can render as a self-hosted "Getting Started" page). Emphasize simplicity: "Just write Markdown—no code required."
+To make Archivox truly user-friendly, include these instructions in the starter repo's `README.md` (which can render as a self-hosted "Getting Started" page). Emphasize simplicity: "Just write Markdown—no code required."
 
 ### Placing Files and Folders
 - **Create Sections**: Use folders for top-level sections (e.g., `content/guides/`). Subfolders nest subsections (e.g., `content/guides/basics/`).
@@ -246,7 +246,7 @@ To make DocForge truly user-friendly, include these instructions in the starter 
 ## Creating Custom Plugins
 
 Plugins are plain Node.js modules placed in the folder defined by `pluginsDir`.
-Each module can export hook functions which DocForge calls during the build:
+Each module can export hook functions which Archivox calls during the build:
 
 ```js
 module.exports = {

--- a/bin/create-archivox.js
+++ b/bin/create-archivox.js
@@ -29,8 +29,8 @@ function main() {
   if (fs.existsSync(pkgPath)) {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
     const version = require('../package.json').version;
-    if (pkg.dependencies && pkg.dependencies.docforge)
-      pkg.dependencies.docforge = `^${version}`;
+    if (pkg.dependencies && pkg.dependencies.archivox)
+      pkg.dependencies.archivox = `^${version}`;
     pkg.name = path.basename(targetDir);
     fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
   }
@@ -39,7 +39,7 @@ function main() {
     execSync('npm install', { cwd: targetDir, stdio: 'inherit' });
   }
 
-  console.log(`DocForge starter created at ${targetDir}`);
+  console.log(`Archivox starter created at ${targetDir}`);
 }
 
 main();

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,5 +1,5 @@
 site:
-  title: "DocForge Docs"
+  title: "Archivox Docs"
   description: "Simple static docs."
 
 navigation:
@@ -8,6 +8,6 @@ navigation:
 footer:
   links:
     - text: "GitHub"
-      url: "https://github.com/yourusername/DocForge"
+      url: "https://github.com/yourusername/Archivox"
     - text: "License"
       url: "/license.html"

--- a/docs/content/advanced/api/endpoints.md
+++ b/docs/content/advanced/api/endpoints.md
@@ -1,3 +1,3 @@
 # API Endpoints
 
-If you expose APIs for your project, document them here. DocForge does not impose any format—just write Markdown.
+If you expose APIs for your project, document them here. Archivox does not impose any format—just write Markdown.

--- a/docs/content/deployment/index.md
+++ b/docs/content/deployment/index.md
@@ -1,6 +1,6 @@
 # Deployment
 
-DocForge sites output to the `_site/` folder. Host the contents on any static server. For Netlify, include a `netlify.toml` file:
+Archivox sites output to the `_site/` folder. Host the contents on any static server. For Netlify, include a `netlify.toml` file:
 
 ```toml
 [build]

--- a/docs/content/features/index.md
+++ b/docs/content/features/index.md
@@ -1,6 +1,6 @@
 # Features Overview
 
-DocForge automatically turns your Markdown files into a full documentation site with a responsive layout and search.
+Archivox automatically turns your Markdown files into a full documentation site with a responsive layout and search.
 
 * Sidebar navigation generated from folders
 * Collapsible mobile menu and dark-mode switch

--- a/docs/content/getting-started/01-install.md
+++ b/docs/content/getting-started/01-install.md
@@ -1,4 +1,4 @@
-# Install DocForge
+# Install Archivox
 
 1. Clone or download this repository.
 2. Run `npm install` to install dependencies.

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -1,3 +1,3 @@
 # Getting Started
 
-This section walks you through installing DocForge and creating your first site.
+This section walks you through installing Archivox and creating your first site.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,6 @@
-# DocForge Documentation
+# Archivox Documentation
 
-Welcome to the official documentation for **DocForge**, a lightweight static site generator designed for "Read&nbsp;the&nbsp;Docs" style websites.
+Welcome to the official documentation for **Archivox**, a lightweight static site generator designed for "Read&nbsp;the&nbsp;Docs" style websites.
 
 ## Quick Start
 
@@ -10,6 +10,6 @@ npm run dev # start local server at http://localhost:8080
 npm run build # generate the _site/ folder
 ```
 
-DocForge converts Markdown files inside a `content/` folder into a full documentation site with search, navigation, and responsive design.
+Archivox converts Markdown files inside a `content/` folder into a full documentation site with search, navigation, and responsive design.
 
-Check the **Getting Started** section to learn how to install and run DocForge locally.
+Check the **Getting Started** section to learn how to install and run Archivox locally.

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "scripts": {
     "dev": "eleventy --serve",
-    "build": "node node_modules/docforge/src/generator/index.js"
+    "build": "node node_modules/archivox/src/generator/index.js"
   },
   "dependencies": {
-    "docforge": "^1.0.0"
+    "archivox": "^1.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "docforge",
+  "name": "archivox",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "docforge",
+      "name": "archivox",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
         "marked": "^11.1.1"
       },
       "bin": {
-        "create-docforge": "bin/create-docforge.js"
+        "create-archivox": "bin/create-archivox.js"
       },
       "devDependencies": {
         "jest": "^29.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "docforge",
+  "name": "archivox",
   "version": "1.0.0",
-  "description": "DocForge static site generator",
+  "description": "Archivox static site generator",
   "scripts": {
     "dev": "eleventy --serve",
     "build": "node src/generator/index.js",
@@ -20,6 +20,6 @@
   },
   "license": "MIT",
   "bin": {
-    "create-docforge": "./bin/create-docforge.js"
+    "create-archivox": "./bin/create-archivox.js"
   }
 }

--- a/src/config/loadConfig.js
+++ b/src/config/loadConfig.js
@@ -30,7 +30,7 @@ function loadConfig(configPath = path.join(process.cwd(), 'config.yaml')) {
 
   const defaults = {
     site: {
-      title: 'DocForge',
+      title: 'Archivox',
       description: '',
       logo: '',
       favicon: ''

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -1,4 +1,4 @@
-// Generator entry point for DocForge
+// Generator entry point for Archivox
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
@@ -210,7 +210,7 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
   }
 
   // Copy the main assets directory (theme, js, etc.)
-  // Always resolve assets relative to the DocForge package so it works
+  // Always resolve assets relative to the Archivox package so it works
   // regardless of the current working directory or config location.
   const mainAssetsSrc = path.resolve(__dirname, '../../assets');
   const mainAssetsDest = path.join(outputDir, 'assets');

--- a/starter/config.yaml
+++ b/starter/config.yaml
@@ -1,5 +1,5 @@
 site:
-  title: "DocForge Docs"
+  title: "Archivox Docs"
   description: "Simple static docs."
 
 navigation:

--- a/starter/content/getting-started/index.md
+++ b/starter/content/getting-started/index.md
@@ -1,3 +1,3 @@
 # Getting Started
 
-This section helps you begin with DocForge.
+This section helps you begin with Archivox.

--- a/starter/content/index.md
+++ b/starter/content/index.md
@@ -1,3 +1,3 @@
-# Welcome to DocForge
+# Welcome to Archivox
 
 This is your new documentation site. Start editing files in the `content/` folder.

--- a/starter/package.json
+++ b/starter/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-docforge-site",
+  "name": "my-archivox-site",
   "private": true,
   "scripts": {
     "dev": "eleventy --serve",
-    "build": "node node_modules/docforge/src/generator/index.js"
+    "build": "node node_modules/archivox/src/generator/index.js"
   },
   "dependencies": {
-    "docforge": "*"
+    "archivox": "*"
   }
 }


### PR DESCRIPTION
## Summary
- rename the project from DocForge to Archivox throughout
- update CLI script and package metadata

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68700a743024832ba4c787330d4a3398